### PR TITLE
arc: add XY mem support

### DIFF
--- a/boards/arc/em_starterkit/arc_mpu_regions.c
+++ b/boards/arc/em_starterkit/arc_mpu_regions.c
@@ -29,6 +29,21 @@ static struct arc_mpu_region mpu_regions[] = {
 			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
 #endif
 
+#if DT_REG_SIZE(DT_INST(0, arc_xccm)) > 0
+	/* Region XCCM */
+	MPU_REGION_ENTRY("XCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_xccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_xccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
+#if DT_REG_SIZE(DT_INST(0, arc_yccm)) > 0
+	/* Region YCCM */
+	MPU_REGION_ENTRY("YCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_yccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_yccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
+
 #if DT_REG_SIZE(DT_INST(0, mmio_sram)) > 0
 	/* Region DDR RAM */
 	MPU_REGION_ENTRY("DDR RAM",

--- a/boards/arc/em_starterkit/em_starterkit.dts
+++ b/boards/arc/em_starterkit/em_starterkit.dts
@@ -36,6 +36,16 @@
 		compatible = "arc,dccm";
 		reg = <0x80000000 DT_SIZE_K(128)>;
 	};
+
+	xccm@c0000000 {
+		compatible = "arc,xccm";
+		reg = <0xc0000000 DT_SIZE_K(8)>;
+	};
+
+	yccm@e0000000 {
+		compatible = "arc,yccm";
+		reg = <0xe0000000 DT_SIZE_K(8)>;
+	};
 };
 
 &uart1 {

--- a/boards/arc/em_starterkit/em_starterkit_em11d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.dts
@@ -36,6 +36,16 @@
 		compatible = "arc,dccm";
 		reg = <0x80000000 DT_SIZE_K(64)>;
 	};
+
+	xccm@c0000000 {
+		compatible = "arc,xccm";
+		reg = <0xc0000000 DT_SIZE_K(8)>;
+	};
+
+	yccm@e0000000 {
+		compatible = "arc,yccm";
+		reg = <0xe0000000 DT_SIZE_K(8)>;
+	};
 };
 
 &uart1 {

--- a/boards/arc/emsdp/arc_mpu_regions.c
+++ b/boards/arc/emsdp/arc_mpu_regions.c
@@ -20,6 +20,20 @@ static struct arc_mpu_region mpu_regions[] = {
 			 DT_REG_ADDR(DT_INST(0, arc_dccm)),
 			 DT_REG_SIZE(DT_INST(0, arc_dccm)),
 			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+	/* Region XCCM */
+#if DT_REG_SIZE(DT_INST(0, arc_xccm)) > 0
+	MPU_REGION_ENTRY("XCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_xccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_xccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
+	/* Region YCCM */
+#if DT_REG_SIZE(DT_INST(0, arc_yccm)) > 0
+	MPU_REGION_ENTRY("YCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_yccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_yccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
 	/* Region DDR RAM */
 	MPU_REGION_ENTRY("SRAM",
 			DT_REG_ADDR(DT_INST(0, mmio_sram)),

--- a/boards/arc/emsdp/emsdp.dts
+++ b/boards/arc/emsdp/emsdp.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <synopsys/emsdp.dtsi>
+#include <mem.h>
 #include "board.dtsi"
 
 / {

--- a/boards/arc/emsdp/emsdp_em9d.dts
+++ b/boards/arc/emsdp/emsdp_em9d.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <synopsys/emsdp.dtsi>
+#include <mem.h>
 #include "board.dtsi"
 
 / {
@@ -21,6 +22,16 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+	};
+
+	xccm@c0000000 {
+		compatible = "arc,xccm";
+		reg = <0xc0000000 DT_SIZE_K(16)>;
+	};
+
+	yccm@e0000000 {
+		compatible = "arc,yccm";
+		reg = <0xe0000000 DT_SIZE_K(16)>;
 	};
 };
 

--- a/boards/arc/iotdk/arc_mpu_regions.c
+++ b/boards/arc/iotdk/arc_mpu_regions.c
@@ -20,6 +20,20 @@ static struct arc_mpu_region mpu_regions[] = {
 			 DT_REG_ADDR(DT_INST(0, arc_dccm)),
 			 DT_REG_SIZE(DT_INST(0, arc_dccm)),
 			 REGION_KERNEL_RAM_ATTR),
+	/* Region XCCM */
+#if DT_REG_SIZE(DT_INST(0, arc_xccm)) > 0
+	MPU_REGION_ENTRY("XCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_xccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_xccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
+	/* Region YCCM */
+#if DT_REG_SIZE(DT_INST(0, arc_yccm)) > 0
+	MPU_REGION_ENTRY("YCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_yccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_yccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
 	/* Region DDR RAM */
 	MPU_REGION_ENTRY("SRAM",
 			CONFIG_SRAM_BASE_ADDRESS,

--- a/boards/arc/iotdk/iotdk.dts
+++ b/boards/arc/iotdk/iotdk.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <synopsys/arc_iot.dtsi>
+#include <mem.h>
 #include "board.dtsi"
 
 / {
@@ -22,6 +23,16 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+	};
+
+	xccm@c0000000 {
+		compatible = "arc,xccm";
+		reg = <0xc0000000 DT_SIZE_K(32)>;
+	};
+
+	yccm@e0000000 {
+		compatible = "arc,yccm";
+		reg = <0xe0000000 DT_SIZE_K(32)>;
 	};
 };
 

--- a/boards/arc/nsim/arc_mpu_regions.c
+++ b/boards/arc/nsim/arc_mpu_regions.c
@@ -37,7 +37,20 @@ static struct arc_mpu_region mpu_regions[] = {
 			 DT_REG_SIZE(DT_INST(0, arc_dccm)),
 			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
 #endif
-
+#if DT_REG_SIZE(DT_INST(0, arc_xccm)) > 0
+	/* Region XCCM */
+	MPU_REGION_ENTRY("XCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_xccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_xccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
+#if DT_REG_SIZE(DT_INST(0, arc_yccm)) > 0
+	/* Region YCCM */
+	MPU_REGION_ENTRY("YCCM",
+			 DT_REG_ADDR(DT_INST(0, arc_yccm)),
+			 DT_REG_SIZE(DT_INST(0, arc_yccm)),
+			 REGION_KERNEL_RAM_ATTR | REGION_DYNAMIC),
+#endif
 /*
  * Region peripheral is shared by secure world and normal world by default,
  * no need a static mpu entry. If some peripherals belong to secure world,

--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -9,6 +9,22 @@
 #include "skeleton.dtsi"
 #include <mem.h>
 
+#ifndef ICCM_ADDR
+#define ICCM_ADDR 0
+#endif
+
+#ifndef ICCM_SIZE
+#define ICCM_SIZE DT_SIZE_K(1024)
+#endif
+
+#ifndef DCCM_ADDR
+#define DCCM_ADDR 80000000
+#endif
+
+#ifndef DCCM_SIZE
+#define DCCM_SIZE DT_SIZE_K(1024)
+#endif
+
 / {
 	cpus {
 		#address-cells = <1>;

--- a/boards/arc/nsim/nsim_em.dts
+++ b/boards/arc/nsim/nsim_em.dts
@@ -8,9 +8,35 @@
 
 #include "nsim_em.dtsi"
 
+#ifndef XCCM_ADDR
+#define XCCM_ADDR c0000000
+#endif
+
+#ifndef XCCM_SIZE
+#define XCCM_SIZE DT_SIZE_K(64)
+#endif
+
+#ifndef YCCM_ADDR
+#define YCCM_ADDR e0000000
+#endif
+
+#ifndef YCCM_SIZE
+#define YCCM_SIZE DT_SIZE_K(64)
+#endif
+
 / {
 	model = "snps,nsim_em";
 	compatible = "snps,nsim_em";
+
+	xccm0: xccm@XCCM_ADDR {
+		compatible = "arc,xccm";
+		reg = <DT_ADDR(XCCM_ADDR) XCCM_SIZE>;
+	};
+
+	yccm0: yccm@YCCM_ADDR {
+		compatible = "arc,yccm";
+		reg = <DT_ADDR(YCCM_ADDR) YCCM_SIZE>;
+	};
 };
 
 &cpu0 {

--- a/boards/arc/nsim/support/mdb_em.args
+++ b/boards/arc/nsim/support/mdb_em.args
@@ -22,9 +22,10 @@
 	-Xagu_wb_depth=4
 	-Xagu_accord
 	-Xxy
-	-Xxy_config=dccm_y
-	-Xxy_size=8K
+	-Xxy_config=dccm_x_y
+	-Xxy_size=64K
 	-Xxy_interleave
+	-Xxy_x_base=0xc0000000
 	-Xxy_y_base=0xe0000000
 	-Xfpus_div
 	-Xfpu_mac

--- a/boards/arc/nsim/support/nsim_em.props
+++ b/boards/arc/nsim/support/nsim_em.props
@@ -28,9 +28,10 @@
 	nsim_isa_agu_wb_depth=4
 	nsim_isa_agu_accord=1
 	nsim_isa_xy=1
-	nsim_isa_xy_config=dccm_y
-	nsim_isa_xy_size=8K
+	nsim_isa_xy_config=dccm_x_y
+	nsim_isa_xy_size=64K
 	nsim_isa_xy_interleave=1
+	nsim_isa_xy_x_base=0xc0000000
 	nsim_isa_xy_y_base=0xe0000000
 	nsim_isa_fpus_div_option=1
 	nsim_isa_fpu_mac_option=1

--- a/dts/bindings/arc/arc,xccm.yaml
+++ b/dts/bindings/arc/arc,xccm.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2017, synopsy
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARC XCCM
+
+compatible: "arc,xccm"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true

--- a/dts/bindings/arc/arc,yccm.yaml
+++ b/dts/bindings/arc/arc,yccm.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2017, synopsy
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARC YCCM
+
+compatible: "arc,yccm"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -63,6 +63,12 @@ MEMORY {
 #ifdef DCCM_START
 	DCCM  (rw)  : ORIGIN = DCCM_START,  LENGTH = DCCM_SIZE
 #endif
+#ifdef XCCM_START
+	XCCM  (rw)  : ORIGIN = XCCM_START, 	LENGTH = XCCM_SIZE
+#endif
+#ifdef YCCM_START
+	YCCM  (rw)  : ORIGIN = YCCM_START,  LENGTH = YCCM_SIZE
+#endif
 	/* Used by and documented in include/linker/intlist.ld */
 	IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }

--- a/include/zephyr/arch/arc/v2/xy_mem.ld
+++ b/include/zephyr/arch/arc/v2/xy_mem.ld
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_NODE_HAS_PROP(DT_INST(0, arc_xccm), reg) && \
+    (DT_REG_SIZE(DT_INST(0, arc_xccm)) > 0)
+#define XCCM_START		DT_REG_ADDR(DT_INST(0, arc_xccm))
+#define XCCM_SIZE		DT_REG_SIZE(DT_INST(0, arc_xccm))
+#endif
+
+#if DT_NODE_HAS_PROP(DT_INST(0, arc_yccm), reg) && \
+    (DT_REG_SIZE(DT_INST(0, arc_yccm)) > 0)
+#define YCCM_START		DT_REG_ADDR(DT_INST(0, arc_yccm))
+#define YCCM_SIZE		DT_REG_SIZE(DT_INST(0, arc_yccm))
+#endif

--- a/soc/arc/snps_arc_iot/linker.ld
+++ b/soc/arc/snps_arc_iot/linker.ld
@@ -42,4 +42,5 @@
 #define DCCM_SIZE		DT_REG_SIZE(DT_INST(0, arc_dccm))
 #endif
 
+#include <zephyr/arch/arc/v2/xy_mem.ld>
 #include <zephyr/arch/arc/v2/linker.ld>

--- a/soc/arc/snps_emsdp/linker.ld
+++ b/soc/arc/snps_emsdp/linker.ld
@@ -38,4 +38,5 @@
 #define DCCM_SIZE		DT_REG_SIZE(DT_INST(0, arc_dccm))
 #endif
 
+#include <zephyr/arch/arc/v2/xy_mem.ld>
 #include <zephyr/arch/arc/v2/linker.ld>

--- a/soc/arc/snps_emsk/linker.ld
+++ b/soc/arc/snps_emsk/linker.ld
@@ -39,4 +39,5 @@
 #define DCCM_SIZE		DT_REG_SIZE(DT_INST(0, arc_dccm))
 #endif
 
+#include <zephyr/arch/arc/v2/xy_mem.ld>
 #include <zephyr/arch/arc/v2/linker.ld>

--- a/soc/arc/snps_nsim/linker.ld
+++ b/soc/arc/snps_nsim/linker.ld
@@ -33,4 +33,5 @@
 #define SRAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
 #endif
 
+#include <zephyr/arch/arc/v2/xy_mem.ld>
 #include <zephyr/arch/arc/v2/linker.ld>


### PR DESCRIPTION
Add arc XY mem configuration for nsim_em, em_starterkit, emsdp and iotdk.

Signed-off-by: Siyuan Cheng <siyuanc@synopsys.com>