### PR TITLE
posix: Ensure CLOCK_REALTIME and CLOCK_MONOTONIC use Zephyr clock IDs

### DIFF
--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -66,9 +66,8 @@ struct itimerspec {
 extern "C" {
 #endif
 
-#ifndef CLOCK_REALTIME
+#undef CLOCK_REALTIME
 #define CLOCK_REALTIME SYS_CLOCK_REALTIME
-#endif
 
 #ifndef CLOCK_PROCESS_CPUTIME_ID
 #define CLOCK_PROCESS_CPUTIME_ID 2
@@ -78,13 +77,11 @@ extern "C" {
 #define CLOCK_THREAD_CPUTIME_ID 3
 #endif
 
-#ifndef CLOCK_MONOTONIC
+#undef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC SYS_CLOCK_MONOTONIC
-#endif
 
-#ifndef TIMER_ABSTIME
+#undef TIMER_ABSTIME
 #define TIMER_ABSTIME SYS_TIMER_ABSTIME
-#endif
 
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
 int clock_getres(clockid_t clock_id, struct timespec *ts);


### PR DESCRIPTION
Some toolchains may define CLOCK_REALTIME and 
CLOCK_MONOTONIC in their libc headers
with values that differ from Zephyr's internal 
SYS_CLOCK_REALTIME and SYS_CLOCK_MONOTONIC.

To ensure consistent behavior across all boards and  toolchains, undefine these macros and redefine them  to match Zephyr's expected clock IDs.

This prevents mismatched clock IDs being passed to  the kernel, avoiding invalid clockid errors when using  functions like clock_gettime().

Fixing issue: https://github.com/zephyrproject-rtos/zephyr/issues/93073